### PR TITLE
Added "Ctrl+Z" and "Ctrl+Y" capabilities for the Review Process components

### DIFF
--- a/force-app/main/default/lwc/keyboardUndoRedoUtils/keyboardUndoRedoUtils.js
+++ b/force-app/main/default/lwc/keyboardUndoRedoUtils/keyboardUndoRedoUtils.js
@@ -1,0 +1,68 @@
+const historyMap = new WeakMap();
+const elementListenerMap = new WeakMap();
+
+function deepClone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+}
+
+function peek(stack) {
+    return stack[stack.length - 1];
+}
+
+export const keyboardUndoRedoUtils = {
+    register(component, options) {
+        const { getState, setState, element } = options;
+
+        const undoStack = [];
+        const redoStack = [];
+
+        undoStack.push(deepClone(getState()));
+
+        const keyHandler = (event) => {
+            if (!(event.ctrlKey || event.metaKey)) return;
+
+            const key = event.key.toLowerCase();
+            if (key === 'z') {
+                event.preventDefault();
+                if (undoStack.length > 1) {
+                    const current = undoStack.pop();
+                    redoStack.push(current);
+                    
+                    const prev = peek(undoStack);
+                    setState(deepClone(prev));
+                }
+            } else if (key === 'y') {
+                event.preventDefault();
+                if (redoStack.length > 0) {
+                    const next = redoStack.pop();
+                    undoStack.push(next);
+                    setState(deepClone(next));
+                }
+            }
+        };
+
+        element.addEventListener('keydown', keyHandler);
+        element.tabIndex = 0;
+
+        elementListenerMap.set(component, { keyHandler, element });
+        historyMap.set(component, { undoStack, redoStack, getState, setState });
+    },
+
+    unregister(component) {
+        const listenerData = elementListenerMap.get(component);
+        if (listenerData) {
+            listenerData.element.removeEventListener('keydown', listenerData.keyHandler);
+            elementListenerMap.delete(component);
+        }
+        historyMap.delete(component);
+    },
+
+    pushState(component) {
+        const history = historyMap.get(component);
+        if (history) {
+            const snapshot = deepClone(history.getState());
+            history.undoStack.push(snapshot);
+            history.redoStack.length = 0;
+        }
+    }
+};

--- a/force-app/main/default/lwc/keyboardUndoRedoUtils/keyboardUndoRedoUtils.js-meta.xml
+++ b/force-app/main/default/lwc/keyboardUndoRedoUtils/keyboardUndoRedoUtils.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/reviewProcessFieldPicker/reviewProcessFieldPicker.html
+++ b/force-app/main/default/lwc/reviewProcessFieldPicker/reviewProcessFieldPicker.html
@@ -1,5 +1,5 @@
 <template>
-    <div class="slds-grid slds-wrap" style="position: relative;">
+    <div lwc:ref="fieldsContainer" class="slds-grid slds-wrap">
         <lightning-spinner lwc:if={isLoading} alternative-text="Loading..." size="small"></lightning-spinner>
 
         <div class="slds-grid slds-wrap full-width"> 

--- a/force-app/main/default/lwc/reviewProcessRecordFilter/reviewProcessRecordFilter.html
+++ b/force-app/main/default/lwc/reviewProcessRecordFilter/reviewProcessRecordFilter.html
@@ -1,5 +1,5 @@
 <template>
-    <div class="slds-grid slds-wrap">
+    <div lwc:ref="filtersContainer" class="slds-grid slds-wrap">
         <lightning-spinner lwc:if={isLoading} alternative-text="Loading..." size="small"></lightning-spinner>
 
         <div class="slds-grid slds-nowrap slds-size_12-of-12 slds-grid_vertical-align-end">


### PR DESCRIPTION
Implemented as an encapsulated `keyboardUndoRedoUtils` file that can be imported into specific components and allows you to configure which data should have history and rollback capabilities.

Even though issue #5 only required this functionality for one component, the usage was so straightforward that the utility was added to both components on the Review Process page.